### PR TITLE
Fixes #168, scrollbutton glitch

### DIFF
--- a/paper-tabs.html
+++ b/paper-tabs.html
@@ -511,7 +511,7 @@ Custom property | Description | Default
         var scrollLeft = this.$.tabsContainer.scrollLeft;
 
         this._leftHidden = scrollLeft === 0;
-        this._rightHidden = scrollLeft === this._tabContainerScrollSize;
+        this._rightHidden = Math.ceil(scrollLeft) >= this._tabContainerScrollSize;
       },
 
       _onLeftScrollButtonDown: function() {


### PR DESCRIPTION
This fixes #168. When using Browser-Zoom scrollLeft can be a decimal number. Using Math.ceil on scrollLeft will ensure that the condition will be met in this case and the rightHidden will be set properly.
